### PR TITLE
feat: Add starter battery voltage to smart shunt

### DIFF
--- a/lib/ui/src/ui_batteryScreen.c
+++ b/lib/ui/src/ui_batteryScreen.c
@@ -5,7 +5,7 @@
 
 #include "ui.h"
 
-lv_obj_t *ui_batteryScreen = NULL;lv_obj_t *ui_SBattVArc = NULL;lv_obj_t *ui_SA1Arc = NULL;lv_obj_t *ui_battVLabelSensor = NULL;lv_obj_t *ui_battALabelSensor = NULL;lv_obj_t *ui_batteryVLabel = NULL;lv_obj_t *ui_batteryALabel = NULL;lv_obj_t *ui_startBatteryLabel = NULL;lv_obj_t *ui_aeIconBatteryScreen1 = NULL;lv_obj_t *ui_Image1 = NULL;lv_obj_t *ui_BatteryTime = NULL;lv_obj_t *ui_SOCLabel = NULL;lv_obj_t *ui_meshIndicator = NULL;
+lv_obj_t *ui_batteryScreen = NULL;lv_obj_t *ui_SBattVArc = NULL;lv_obj_t *ui_SA1Arc = NULL;lv_obj_t *ui_battVLabelSensor = NULL;lv_obj_t *ui_battALabelSensor = NULL;lv_obj_t *ui_batteryVLabel = NULL;lv_obj_t *ui_batteryALabel = NULL;lv_obj_t *ui_startBatteryLabel = NULL;lv_obj_t *ui_starterBatteryVoltageLabel = NULL;lv_obj_t *ui_aeIconBatteryScreen1 = NULL;lv_obj_t *ui_Image1 = NULL;lv_obj_t *ui_BatteryTime = NULL;lv_obj_t *ui_SOCLabel = NULL;lv_obj_t *ui_meshIndicator = NULL;
 // event funtions
 void ui_event_aeIconBatteryScreen1( lv_event_t * e) {
     lv_event_code_t event_code = lv_event_get_code(e);
@@ -126,6 +126,18 @@ lv_obj_set_style_text_color(ui_startBatteryLabel, lv_color_hex(0xFFFFFF), LV_PAR
 lv_obj_set_style_text_opa(ui_startBatteryLabel, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_startBatteryLabel, &lv_font_montserrat_20, LV_PART_MAIN| LV_STATE_DEFAULT);
 
+ui_starterBatteryVoltageLabel = lv_label_create(ui_batteryScreen);
+lv_obj_set_width( ui_starterBatteryVoltageLabel, LV_SIZE_CONTENT);
+lv_obj_set_height( ui_starterBatteryVoltageLabel, LV_SIZE_CONTENT);
+lv_obj_set_x( ui_starterBatteryVoltageLabel, 0 );
+lv_obj_set_y( ui_starterBatteryVoltageLabel, 125 );
+lv_obj_set_align( ui_starterBatteryVoltageLabel, LV_ALIGN_CENTER );
+lv_label_set_text(ui_starterBatteryVoltageLabel,"12.8V");
+lv_obj_clear_flag( ui_starterBatteryVoltageLabel, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN );
+lv_obj_set_style_text_color(ui_starterBatteryVoltageLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
+lv_obj_set_style_text_opa(ui_starterBatteryVoltageLabel, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_font(ui_starterBatteryVoltageLabel, &lv_font_montserrat_26, LV_PART_MAIN| LV_STATE_DEFAULT);
+
 ui_aeIconBatteryScreen1 = lv_img_create(ui_batteryScreen);
 lv_img_set_src(ui_aeIconBatteryScreen1, &ui_img_ae_white_128_png);
 lv_obj_set_width( ui_aeIconBatteryScreen1, LV_SIZE_CONTENT);  /// 1
@@ -203,6 +215,7 @@ ui_battALabelSensor= NULL;
 ui_batteryVLabel= NULL;
 ui_batteryALabel= NULL;
 ui_startBatteryLabel= NULL;
+ui_starterBatteryVoltageLabel = NULL;
 ui_aeIconBatteryScreen1= NULL;
 ui_Image1= NULL;
 ui_BatteryTime= NULL;

--- a/lib/ui/src/ui_batteryScreen.h
+++ b/lib/ui/src/ui_batteryScreen.h
@@ -21,6 +21,7 @@ extern lv_obj_t *ui_battALabelSensor;
 extern lv_obj_t *ui_batteryVLabel;
 extern lv_obj_t *ui_batteryALabel;
 extern lv_obj_t *ui_startBatteryLabel;
+extern lv_obj_t *ui_starterBatteryVoltageLabel;
 extern void ui_event_aeIconBatteryScreen1( lv_event_t * e);
 extern lv_obj_t *ui_aeIconBatteryScreen1;
 extern lv_obj_t *ui_Image1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,6 +276,7 @@ static void lv_update_shunt_ui_cb(void *user_data)
 
   // If you have other labels, update them here:
   // lv_label_set_text_fmt(ui_battPowerLabel, "%.2f W", p->batteryPower);
+  lv_label_set_text_fmt(ui_starterBatteryVoltageLabel, "%.2fV", p->starterBatteryVoltage);
 
   enable_ui_batteryScreen = true;
   lv_obj_t *current_screen = lv_scr_act();

--- a/src/shared_defs.h
+++ b/src/shared_defs.h
@@ -65,6 +65,7 @@ typedef struct struct_message_ae_smart_shunt_1 {
   float batteryCapacity;
   int batteryState;
   char runFlatTime[40];
+  float starterBatteryVoltage;
 } __attribute__((packed)) struct_message_ae_smart_shunt_1;
 
 #endif // SHARED_DEFS_H


### PR DESCRIPTION
This change adds support for the `starterBatteryVoltage` field from the `struct_message_ae_smart_shunt_1`.

The following changes were made:
- The `struct_message_ae_smart_shunt_1` in `src/shared_defs.h` was updated to include the new field.
- The battery screen UI was updated to display the new value. This involved adding a new label in `lib/ui/src/ui_batteryScreen.c` and `lib/ui/src/ui_batteryScreen.h`.
- The `lv_update_shunt_ui_cb` function in `src/main.cpp` was updated to set the text of the new label.