### PR TITLE
feat: Implement screen lock and data source configuration

### DIFF
--- a/lib/ui/src/ui.c
+++ b/lib/ui/src/ui.c
@@ -35,6 +35,9 @@ lv_disp_set_theme(dispp, theme);
 ui_bootInitialScreen_screen_init();
 ui_batteryScreen_screen_init();
 ui____initial_actions0 = lv_obj_create(NULL);
+lv_obj_add_event_cb(ui_VictronCheckbox, victronCheckboxToggled, LV_EVENT_VALUE_CHANGED, NULL);
+lv_obj_add_flag(ui_VictronCheckbox, LV_OBJ_FLAG_HIDDEN);
+lv_obj_add_flag(ui_VictronCheckboxLabel, LV_OBJ_FLAG_HIDDEN);
 lv_disp_load_scr( ui_bootInitialScreen);
 }
 

--- a/lib/ui/src/ui_events.c
+++ b/lib/ui/src/ui_events.c
@@ -8,6 +8,7 @@
 #include "../../src/shared_data.h"
 #include <string.h> // For strcmp
 
+extern bool receiveBleData;
 extern bool wifiSetToOn;
 extern bool settingsState;
 extern bool syncFlash;
@@ -92,6 +93,8 @@ void landingBackButtonPressedFunction(lv_event_t *e)
 		lv_obj_add_flag(ui_SSIDLabel, LV_OBJ_FLAG_HIDDEN);
 		lv_obj_add_flag(ui_SSIDPasswordLabel, LV_OBJ_FLAG_HIDDEN);
 		lv_obj_add_flag(ui_landingBackButton, LV_OBJ_FLAG_HIDDEN);
+		lv_obj_add_flag(ui_VictronCheckbox, LV_OBJ_FLAG_HIDDEN);
+		lv_obj_add_flag(ui_VictronCheckboxLabel, LV_OBJ_FLAG_HIDDEN);
 
 		lv_obj_clear_flag(ui_wifiIcon, LV_OBJ_FLAG_HIDDEN);
 		lv_obj_clear_flag(ui_aeLandingIcon, LV_OBJ_FLAG_HIDDEN);
@@ -125,5 +128,26 @@ void landingBackButtonPressedFunction(lv_event_t *e)
 
 void aeLandingIconFunction(lv_event_t *e)
 {
-	// Your code here
+	// Hide landing page icons
+	lv_obj_add_flag(ui_wifiIcon, LV_OBJ_FLAG_HIDDEN);
+	lv_obj_add_flag(ui_aeLandingIcon, LV_OBJ_FLAG_HIDDEN);
+	lv_obj_add_flag(ui_settingsIcon, LV_OBJ_FLAG_HIDDEN);
+	lv_obj_add_flag(ui_aeLandingBottomLabel, LV_OBJ_FLAG_HIDDEN);
+	lv_obj_add_flag(ui_aeLandingBottomIcon, LV_OBJ_FLAG_HIDDEN);
+
+	// Show settings elements
+	lv_label_set_text(ui_feedbackLabel, "Data Source");
+	lv_obj_clear_flag(ui_VictronCheckbox, LV_OBJ_FLAG_HIDDEN);
+	lv_obj_clear_flag(ui_VictronCheckboxLabel, LV_OBJ_FLAG_HIDDEN);
+	lv_label_set_text(ui_VictronCheckboxLabel, "Enable Victron BLE"); // Fix the label text
+	lv_obj_align_to(ui_VictronCheckboxLabel, ui_VictronCheckbox, LV_ALIGN_OUT_RIGHT_MID, 10, 0); // Align label to checkbox
+
+	lv_obj_clear_flag(ui_landingBackButton, LV_OBJ_FLAG_HIDDEN);
+
+	// Set checkbox state from preferences
+	if (receiveBleData) {
+		lv_obj_add_state(ui_VictronCheckbox, LV_STATE_CHECKED);
+	} else {
+		lv_obj_clear_state(ui_VictronCheckbox, LV_STATE_CHECKED);
+	}
 }

--- a/lib/ui/src/ui_events.h
+++ b/lib/ui/src/ui_events.h
@@ -14,6 +14,7 @@ void toggleWiFi(lv_event_t * e);
 void settingsButtonPressedFunction(lv_event_t * e);
 void aeLandingIconFunction(lv_event_t * e);
 void landingBackButtonPressedFunction(lv_event_t * e);
+void victronCheckboxToggled(lv_event_t * e);
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
This commit introduces two main features:

1.  A 60-second screen lock to prevent automatic screen changes after user interaction. A timestamp is updated on any touch or encoder activity, and incoming data will not trigger a screen change until 60 seconds of inactivity have passed.

2.  A data source configuration screen to switch between ESP-NOW and Victron BLE data sources. This setting is accessible via an icon on the main screen and is persisted across reboots.